### PR TITLE
Mimic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+### Mimic
+
+This version brings integration with Mimic and **makes it required** for MarkItem.
+Integration with Mimic allows:
+- Get mark item via Mimic API or command. You can use marks everywhere where Mimic is supported (with id `markitem:mark`).
+- Use any items from plugins supporting Mimic as a texture for mark item.
+
 ### More reliable marks
 
 > **BREAKING CHANGE!** Marks created in v0.5 can't be used anymore.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ You can configure title and description of the "Marked Item" recipe that will be
 
 ```yaml
 recipe:
+  texture: red_dye
   title: "Marked Item"
   description:
     - "You can mark your items to keep it on death"

--- a/annotations/org/bukkit/configuration/annotations.xml
+++ b/annotations/org/bukkit/configuration/annotations.xml
@@ -1,0 +1,7 @@
+<root>
+    <item name='org.bukkit.configuration.ConfigurationSection java.lang.String getString(java.lang.String, java.lang.String)'>
+        <annotation name='org.jetbrains.annotations.Contract'>
+            <val val="&quot;_, !null -&gt; !null&quot;"/>
+        </annotation>
+    </item>
+</root>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,4 +32,5 @@ bukkit {
 dependencies {
     compileOnly(spigotApi)
     compileOnly("org.jetbrains:annotations:23.0.0")
+    compileOnly("ru.endlesscode.mimic:mimic-bukkit-api:0.8.0")
 }

--- a/src/main/java/ru/endlesscode/markitem/CommandExecutor.java
+++ b/src/main/java/ru/endlesscode/markitem/CommandExecutor.java
@@ -4,28 +4,36 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 class CommandExecutor {
-    public static void giveMark(CommandSender sender) {
+
+    private final ItemsProvider itemsProvider;
+
+    CommandExecutor(ItemsProvider itemsProvider) {
+        this.itemsProvider = itemsProvider;
+    }
+
+    void giveMark(CommandSender sender) {
         if (sender instanceof Player) {
             giveMark((Player) sender);
         } else {
-            sender.sendMessage("It is player side command");
+            sender.sendMessage("This command should be executed by player");
         }
     }
 
 
-    public static void giveMark(CommandSender sender, String name) {
+    void giveMark(CommandSender sender, String name) {
         Player player = sender.getServer().getPlayer(name);
 
         if (player == null) {
             sender.sendMessage("Player " + name + " not found.");
         } else {
             giveMark(player);
+            sender.sendMessage("Gave mark to " + name);
         }
     }
 
-    private static void giveMark(Player player) {
+    private void giveMark(Player player) {
         if (player.getInventory().firstEmpty() != -1) {
-            player.getInventory().addItem(MarkItem.getItemMarker().getMark());
+            player.getInventory().addItem(itemsProvider.getMark());
         }
     }
 }

--- a/src/main/java/ru/endlesscode/markitem/Config.java
+++ b/src/main/java/ru/endlesscode/markitem/Config.java
@@ -18,6 +18,7 @@ class Config {
     private List<String> markText = Collections.emptyList();
     private List<String> markLore = Collections.emptyList();
 
+    private String recipeTexture = "";
     private String recipeTitle = "";
     private List<String> recipeDescription = Collections.emptyList();
 
@@ -39,6 +40,7 @@ class Config {
         markText = getColorizedStringList("mark.text");
         markLore = getColorizedStringList("mark.lore");
 
+        recipeTexture = getColorizedString("recipe.texture", markTexture);
         recipeTitle = getColorizedString("recipe.title");
         recipeDescription = getColorizedStringList("recipe.description");
 
@@ -47,7 +49,11 @@ class Config {
     }
 
     private String getColorizedString(String path) {
-        return Strings.colorize(configuration.getString(path, ""));
+        return getColorizedString(path, "");
+    }
+
+    private String getColorizedString(String path, String def) {
+        return Strings.colorize(configuration.getString(path, def));
     }
 
     private List<String> getColorizedStringList(String path) {
@@ -82,6 +88,10 @@ class Config {
 
     public List<String> getMarkLore() {
         return markLore;
+    }
+
+    public String getRecipeTexture() {
+        return recipeTexture;
     }
 
     public String getRecipeTitle() {

--- a/src/main/java/ru/endlesscode/markitem/ItemMarker.java
+++ b/src/main/java/ru/endlesscode/markitem/ItemMarker.java
@@ -154,7 +154,7 @@ public class ItemMarker implements Listener {
         return KEY_RECIPE.equals(((ShapelessRecipe) recipe).getKey());
     }
 
-    private boolean isMark(@NotNull ItemStack itemStack) {
+    static boolean isMark(@NotNull ItemStack itemStack) {
         return Items.hasFlag(itemStack, KEY_MARK);
     }
 }

--- a/src/main/java/ru/endlesscode/markitem/ItemsProvider.java
+++ b/src/main/java/ru/endlesscode/markitem/ItemsProvider.java
@@ -1,0 +1,71 @@
+package ru.endlesscode.markitem;
+
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import ru.endlesscode.markitem.util.Items;
+import ru.endlesscode.mimic.items.BukkitItemsRegistry;
+
+import java.util.Objects;
+
+/**
+ * Creates items required for plugin: mark item and recipe item.
+ */
+class ItemsProvider {
+
+    private final Config config;
+    private final BukkitItemsRegistry itemsRegistry;
+
+    @Nullable
+    private ItemStack mark = null;
+    @Nullable
+    private ItemStack recipeItem = null;
+
+    ItemsProvider(Config config, BukkitItemsRegistry itemsRegistry) {
+        this.config = config;
+        this.itemsRegistry = itemsRegistry;
+    }
+
+    synchronized @NotNull ItemStack getMark() {
+        if (mark == null) mark = createMark();
+        return mark;
+    }
+
+    private @NotNull ItemStack createMark() {
+        ItemStack result = requireItem(config.getMarkTexture(), "mark.texture");
+
+        Items.editItemMeta(result, im -> {
+            im.setDisplayName(config.getMarkName());
+            im.setLore(config.getMarkLore());
+        });
+
+        return result;
+    }
+
+    synchronized @NotNull ItemStack getRecipeItem() {
+        if (recipeItem == null) recipeItem = createRecipeItem();
+        return recipeItem;
+    }
+
+    private @NotNull ItemStack createRecipeItem() {
+        ItemStack result = requireItem(config.getRecipeTexture(), "recipe.texture");
+
+        Items.editItemMeta(result, im -> {
+            im.setDisplayName(config.getRecipeTitle());
+            im.setLore(config.getRecipeDescription());
+        });
+
+        return result;
+    }
+
+    private @NotNull ItemStack requireItem(@NotNull String id, @NotNull String option) {
+        if (id.startsWith("markitem") || id.equals(MarkItemRegistry.MARK_ID)) {
+            throw new IllegalArgumentException("You can not use item '" + id + "' in option '" + option + "'");
+        }
+
+        return Objects.requireNonNull(
+                itemsRegistry.getItem(id),
+                () -> "Item '" + id + "' not found in Mimic. Please, specify a valid ID in option '" + option + "'"
+        );
+    }
+}

--- a/src/main/java/ru/endlesscode/markitem/ItemsProvider.java
+++ b/src/main/java/ru/endlesscode/markitem/ItemsProvider.java
@@ -1,5 +1,6 @@
 package ru.endlesscode.markitem;
 
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -12,6 +13,8 @@ import java.util.Objects;
  * Creates items required for plugin: mark item and recipe item.
  */
 class ItemsProvider {
+
+    private static final NamespacedKey KEY_MARK = MarkItem.namespacedKey("mark");
 
     private final Config config;
     private final BukkitItemsRegistry itemsRegistry;
@@ -38,8 +41,13 @@ class ItemsProvider {
             im.setDisplayName(config.getMarkName());
             im.setLore(config.getMarkLore());
         });
+        Items.addFlag(result, KEY_MARK);
 
         return result;
+    }
+
+    static boolean isMark(@NotNull ItemStack itemStack) {
+        return Items.hasFlag(itemStack, KEY_MARK);
     }
 
     synchronized @NotNull ItemStack getRecipeItem() {

--- a/src/main/java/ru/endlesscode/markitem/ItemsProvider.java
+++ b/src/main/java/ru/endlesscode/markitem/ItemsProvider.java
@@ -28,7 +28,7 @@ class ItemsProvider {
 
     synchronized @NotNull ItemStack getMark() {
         if (mark == null) mark = createMark();
-        return mark;
+        return mark.clone();
     }
 
     private @NotNull ItemStack createMark() {
@@ -44,7 +44,7 @@ class ItemsProvider {
 
     synchronized @NotNull ItemStack getRecipeItem() {
         if (recipeItem == null) recipeItem = createRecipeItem();
-        return recipeItem;
+        return recipeItem.clone();
     }
 
     private @NotNull ItemStack createRecipeItem() {

--- a/src/main/java/ru/endlesscode/markitem/MarkItem.java
+++ b/src/main/java/ru/endlesscode/markitem/MarkItem.java
@@ -12,11 +12,8 @@ import ru.endlesscode.mimic.MimicApiLevel;
 public class MarkItem extends JavaPlugin {
 
     private static MarkItem instance;
-    private static ItemMarker itemMarker;
 
-    public static ItemMarker getItemMarker() {
-        return itemMarker;
-    }
+    private CommandExecutor commandExecutor;
 
     @NotNull
     public static NamespacedKey namespacedKey(@NotNull String key) {
@@ -43,11 +40,13 @@ public class MarkItem extends JavaPlugin {
             return;
         }
 
-        itemMarker = new ItemMarker(config);
+        ItemsProvider itemsProvider = new ItemsProvider(config, Mimic.getInstance().getItemsRegistry());
+        ItemMarker itemMarker = new ItemMarker(config);
         getServer().getPluginManager().registerEvents(itemMarker, this);
         getServer().getPluginManager().registerEvents(new PlayerInventoryKeeper(), this);
 
-        hookMimic();
+        hookMimic(itemsProvider);
+        commandExecutor = new CommandExecutor(itemsProvider);
     }
 
     private boolean checkMimicEnabled() {
@@ -64,8 +63,8 @@ public class MarkItem extends JavaPlugin {
         return true;
     }
 
-    private void hookMimic() {
-        MarkItemRegistry registry = new MarkItemRegistry(itemMarker.getMark());
+    private void hookMimic(ItemsProvider itemsProvider) {
+        MarkItemRegistry registry = new MarkItemRegistry(itemsProvider);
         Mimic.getInstance().registerItemsRegistry(registry, MimicApiLevel.CURRENT, this);
     }
 
@@ -77,9 +76,9 @@ public class MarkItem extends JavaPlugin {
             String[] args
     ) {
         if (args.length == 0) {
-            CommandExecutor.giveMark(sender);
+            commandExecutor.giveMark(sender);
         } else {
-            CommandExecutor.giveMark(sender, args[0]);
+            commandExecutor.giveMark(sender, args[0]);
         }
 
         return true;

--- a/src/main/java/ru/endlesscode/markitem/MarkItem.java
+++ b/src/main/java/ru/endlesscode/markitem/MarkItem.java
@@ -6,6 +6,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import ru.endlesscode.markitem.util.Log;
+import ru.endlesscode.mimic.MimicApiLevel;
 
 public class MarkItem extends JavaPlugin {
 
@@ -30,14 +31,34 @@ public class MarkItem extends JavaPlugin {
         Config config = new Config(this.getConfig());
 
         if (!config.isEnabled()) {
-            this.getLogger().warning("Plugin is not enabled.");
-            this.setEnabled(false);
+            getLogger().warning("Plugin is not enabled.");
+            setEnabled(false);
+            return;
+        }
+
+        if (!checkMimicEnabled()) {
+            getLogger().severe("Download latest version here: https://www.spigotmc.org/resources/82515/");
+            setEnabled(false);
             return;
         }
 
         itemMarker = new ItemMarker(config);
-        this.getServer().getPluginManager().registerEvents(itemMarker, this);
-        this.getServer().getPluginManager().registerEvents(new PlayerInventoryKeeper(), this);
+        getServer().getPluginManager().registerEvents(itemMarker, this);
+        getServer().getPluginManager().registerEvents(new PlayerInventoryKeeper(), this);
+    }
+
+    private boolean checkMimicEnabled() {
+        if (!getServer().getPluginManager().isPluginEnabled("Mimic")) {
+            getLogger().severe("Mimic is required for the plugin!");
+            return false;
+        }
+
+        if (!MimicApiLevel.checkApiLevel(MimicApiLevel.VERSION_0_7)) {
+            getLogger().severe("Required at least Mimic 0.7!");
+            return false;
+        }
+
+        return true;
     }
 
     @Override

--- a/src/main/java/ru/endlesscode/markitem/MarkItem.java
+++ b/src/main/java/ru/endlesscode/markitem/MarkItem.java
@@ -40,13 +40,16 @@ public class MarkItem extends JavaPlugin {
             return;
         }
 
-        ItemsProvider itemsProvider = new ItemsProvider(config, Mimic.getInstance().getItemsRegistry());
-        ItemMarker itemMarker = new ItemMarker(config);
+        final ItemMarker itemMarker = new ItemMarker(config);
         getServer().getPluginManager().registerEvents(itemMarker, this);
         getServer().getPluginManager().registerEvents(new PlayerInventoryKeeper(), this);
 
+        final ItemsProvider itemsProvider = new ItemsProvider(config, Mimic.getInstance().getItemsRegistry());
         hookMimic(itemsProvider);
         commandExecutor = new CommandExecutor(itemsProvider);
+
+        // Register recipe when all Mimic registries will be available
+        getServer().getScheduler().runTaskLater(this, () -> itemMarker.registerRecipe(itemsProvider), 1L);
     }
 
     private boolean checkMimicEnabled() {

--- a/src/main/java/ru/endlesscode/markitem/MarkItem.java
+++ b/src/main/java/ru/endlesscode/markitem/MarkItem.java
@@ -6,6 +6,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import ru.endlesscode.markitem.util.Log;
+import ru.endlesscode.mimic.Mimic;
 import ru.endlesscode.mimic.MimicApiLevel;
 
 public class MarkItem extends JavaPlugin {
@@ -45,6 +46,8 @@ public class MarkItem extends JavaPlugin {
         itemMarker = new ItemMarker(config);
         getServer().getPluginManager().registerEvents(itemMarker, this);
         getServer().getPluginManager().registerEvents(new PlayerInventoryKeeper(), this);
+
+        hookMimic();
     }
 
     private boolean checkMimicEnabled() {
@@ -59,6 +62,11 @@ public class MarkItem extends JavaPlugin {
         }
 
         return true;
+    }
+
+    private void hookMimic() {
+        MarkItemRegistry registry = new MarkItemRegistry(itemMarker.getMark());
+        Mimic.getInstance().registerItemsRegistry(registry, MimicApiLevel.CURRENT, this);
     }
 
     @Override

--- a/src/main/java/ru/endlesscode/markitem/MarkItemRegistry.java
+++ b/src/main/java/ru/endlesscode/markitem/MarkItemRegistry.java
@@ -1,0 +1,50 @@
+package ru.endlesscode.markitem;
+
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import ru.endlesscode.mimic.items.BukkitItemsRegistry;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Registry with only one item to make it possible to get mark via Mimic.
+ */
+class MarkItemRegistry implements BukkitItemsRegistry {
+
+    private static final String MARK_ID = "mark";
+
+    private final ItemStack markItem;
+
+    MarkItemRegistry(ItemStack markItem) {
+        this.markItem = markItem;
+    }
+
+    @NotNull
+    @Override
+    public Collection<String> getKnownIds() {
+        return Collections.singletonList(MARK_ID);
+    }
+
+    @Nullable
+    @Override
+    public ItemStack getItem(@NotNull String itemId, @Nullable Object payload, int amount) {
+        if (!itemId.equals(MARK_ID)) return null;
+
+        ItemStack mark = markItem.clone();
+        mark.setAmount(amount);
+        return mark;
+    }
+
+    @Nullable
+    @Override
+    public String getItemId(@NotNull ItemStack item) {
+        return ItemMarker.isMark(item) ? MARK_ID : null;
+    }
+
+    @Override
+    public boolean isItemExists(@NotNull String itemId) {
+        return itemId.equals(MARK_ID);
+    }
+}

--- a/src/main/java/ru/endlesscode/markitem/MarkItemRegistry.java
+++ b/src/main/java/ru/endlesscode/markitem/MarkItemRegistry.java
@@ -15,10 +15,10 @@ class MarkItemRegistry implements BukkitItemsRegistry {
 
     static final String MARK_ID = "mark";
 
-    private final ItemStack markItem;
+    private final ItemsProvider itemsProvider;
 
-    MarkItemRegistry(ItemStack markItem) {
-        this.markItem = markItem;
+    MarkItemRegistry(ItemsProvider itemsProvider) {
+        this.itemsProvider = itemsProvider;
     }
 
     @NotNull
@@ -32,7 +32,7 @@ class MarkItemRegistry implements BukkitItemsRegistry {
     public ItemStack getItem(@NotNull String itemId, @Nullable Object payload, int amount) {
         if (!itemId.equals(MARK_ID)) return null;
 
-        ItemStack mark = markItem.clone();
+        ItemStack mark = itemsProvider.getMark();
         mark.setAmount(amount);
         return mark;
     }

--- a/src/main/java/ru/endlesscode/markitem/MarkItemRegistry.java
+++ b/src/main/java/ru/endlesscode/markitem/MarkItemRegistry.java
@@ -13,7 +13,7 @@ import java.util.Collections;
  */
 class MarkItemRegistry implements BukkitItemsRegistry {
 
-    private static final String MARK_ID = "mark";
+    static final String MARK_ID = "mark";
 
     private final ItemStack markItem;
 

--- a/src/main/java/ru/endlesscode/markitem/MarkItemRegistry.java
+++ b/src/main/java/ru/endlesscode/markitem/MarkItemRegistry.java
@@ -40,7 +40,7 @@ class MarkItemRegistry implements BukkitItemsRegistry {
     @Nullable
     @Override
     public String getItemId(@NotNull ItemStack item) {
-        return ItemMarker.isMark(item) ? MARK_ID : null;
+        return ItemsProvider.isMark(item) ? MARK_ID : null;
     }
 
     @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,14 +1,20 @@
 enabled: true
+
+# Configurations for the item to be used as a mark
 mark:
-  texture: RED_DYE
+  # Here you can use any item supported by Mimic
+  texture: red_dye
   name: "&9Mark"
   lore:
     - "&e&oYou can mark your items to keep it on death"
+  # This text will be added to marked items
   text:
     - "&9- Item is marked"
 
 # Recipe will be shown to player in recipe book
 recipe:
+  # Here you can use any item supported by Mimic
+  texture: red_dye
   title: "Marked Item"
   description:
     - "You can mark your items to keep it on death"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,3 +1,5 @@
+softdepend:
+   - Mimic
 commands:
    markitem:
       description: MarkItem command


### PR DESCRIPTION
This PR brings integration with Mimic and **makes it required dependency** for MarkItem.
Integration with Mimic allows:
- Get mark item via Mimic API or command. You can use marks everywhere where Mimic is supported (with id `markitem:mark`).
- Use any items from plugins supporting Mimic as a texture for mark item.